### PR TITLE
[41기 이세윤] 검색어 제안 구현

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,5 +16,13 @@
   "files.autoSave": "onFocusChange",
   "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "workbench.tree.indent": 20,
+  "workbench.colorCustomizations": {
+    "tree.indentGuidesStroke": "#ff5683"
+  },
+  "editor.tokenColorCustomizations": {
+    "comments": "",
+    "textMateRules": []
   }
 }

--- a/src/components/Nav/SearchBar/SuggestionLists.js
+++ b/src/components/Nav/SearchBar/SuggestionLists.js
@@ -1,90 +1,110 @@
 import React from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import styled from 'styled-components';
-import { FaSearch } from 'react-icons/fa';
+import { ImLocation } from 'react-icons/im';
 import theme from '../../../styles/theme';
 
-const RecentList = ({
+const SuggestionLists = ({
   recentSearch,
   setRecentSearch,
   setSearchText,
   setIsFocus,
+  suggestionLists,
 }) => {
   const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
 
   const handleRemove = time => {
-    setRecentSearch(recentSearch.filter(item => item.time !== time));
+    setRecentSearch(recentSearch.filter(list => list.time !== time));
   };
 
   const handleAllRemove = () => {
     setRecentSearch([]);
   };
 
-  const handleSearch = searchText => {
-    searchParams.set('search', searchText);
-    setSearchParams(searchParams);
-    navigate(`/productList?${searchParams.toString()}`);
+  const handleSearch = id => {
+    navigate(`/productDetail/${id}`);
     setIsFocus(false);
     setSearchText('');
   };
 
   return (
     <>
-      <RecentListHeader>
-        <RecentListTitle>최근 검색어</RecentListTitle>
-        <RecentListClear onClick={handleAllRemove}>모두 지우기</RecentListClear>
-      </RecentListHeader>
-      <RecentListBox>
-        {recentSearch &&
-          recentSearch.map(item => {
+      <SuggestionListsHeader>
+        <SuggestionListsTitle />
+        <SuggestionListsClear />
+      </SuggestionListsHeader>
+      <SuggestionListsBox>
+        {suggestionLists &&
+          suggestionLists.map(list => {
             return (
               <RecentQueryWrap
-                key={item.time}
-                onClick={() => handleSearch(item.content)}
+                key={list.shopId}
+                onClick={() => handleSearch(list.shopId)}
               >
-                <RecentQueryItem>
+                <RecentQueryList>
                   <VerticalFocus />
-                  <FaSearch />
+                  <WrapperFaSearch>
+                    <ImLocation size={15} />
+                  </WrapperFaSearch>
                   <RecentSearchQueryContent>
-                    <RecentSearchQuery>{item.content}</RecentSearchQuery>
+                    <RecentSearchQuery>
+                      <ShopName>{list.shopName}</ShopName>
+                      <ShopAddress>{list.shopAddress}</ShopAddress>
+                    </RecentSearchQuery>
                     <RecentSearchInfo>
-                      <RecentInfoTime>
-                        2.6
-                        <Wrapper
-                          onClick={e => {
-                            e.stopPropagation();
-                            handleRemove(item.time);
-                          }}
-                        >
-                          <RecentInfoRemoveImg src="images/close.png" />
-                        </Wrapper>
-                      </RecentInfoTime>
+                      <RecentInfoTime>{list.bread.join(',')}</RecentInfoTime>
                     </RecentSearchInfo>
                   </RecentSearchQueryContent>
-                </RecentQueryItem>
+                </RecentQueryList>
               </RecentQueryWrap>
             );
           })}
-      </RecentListBox>
+      </SuggestionListsBox>
     </>
   );
 };
 
-const RecentListHeader = styled.div`
+const WrapperFaSearch = styled.div`
+  display: flex;
+  flex-direction: column;
+  -webkit-box-align: center;
+  align-items: center;
+  padding-bottom: 0.5rem;
+`;
+
+const ShopName = styled.div`
+  text-align: left;
+  font-size: 0.9375rem;
+  letter-spacing: -0.0469rem;
+  line-height: 1.3125rem;
+  color: rgb(32, 32, 32);
+`;
+
+const ShopAddress = styled.div`
+  font-size: 0.8125rem;
+  line-height: 1.1875rem;
+  color: rgb(126, 126, 126);
+  overflow: hidden;
+  letter-spacing: -0.0406rem;
+  white-space: nowrap;
+  text-align: left;
+`;
+
+const SuggestionListsHeader = styled.div`
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-lists: center;
   padding: 20px 20px 10px;
 `;
 
-const RecentListTitle = styled.span`
+const SuggestionListsTitle = styled.span`
   font-size: 0.9375rem;
   font-weight: 500;
   color: rgb(32, 32, 32);
 `;
 
-const RecentListClear = styled.button`
+const SuggestionListsClear = styled.button`
   font-size: 0.875rem;
   color: rgb(158, 158, 158);
   margin: 0;
@@ -93,14 +113,15 @@ const RecentListClear = styled.button`
   border: transparent;
 `;
 
-const RecentListBox = styled.div``;
+const SuggestionListsBox = styled.div``;
 
 const RecentQueryWrap = styled.div`
   height: 42px;
 `;
 
-const RecentQueryItem = styled.button`
+const RecentQueryList = styled.button`
   display: flex;
+  align-lists: center;
   align-items: center;
   gap: 14px;
   width: 100%;
@@ -123,25 +144,29 @@ const VerticalFocus = styled.div`
 const RecentSearchQueryContent = styled.div`
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-lists: center;
   width: 100%;
   text-align: left;
   font-size: 0.9375rem;
   color: rgb(32, 32, 32);
 `;
 
-const RecentSearchQuery = styled.div``;
+const RecentSearchQuery = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+`;
 
 const RecentSearchInfo = styled.div`
   display: flex;
-  align-items: center;
+  align-lists: center;
   height: 41px;
   padding-top: 0px;
 `;
 
 const RecentInfoTime = styled.span`
   display: flex;
-  align-items: center;
+  align-lists: center;
   gap: 13px;
   font-size: 0.875rem;
   color: rgb(158, 158, 158);
@@ -150,7 +175,7 @@ const RecentInfoTime = styled.span`
 
 const Wrapper = styled.div`
   display: flex;
-  align-items: center;
+  align-lists: center;
   justify-content: center;
   height: 100%;
   width: 20px;
@@ -163,4 +188,4 @@ const RecentInfoRemoveImg = styled.img`
   height: 10px;
 `;
 
-export default RecentList;
+export default SuggestionLists;


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 통신 로직 줄이기
- 초성 검색이나 자음검색시 검색제안은 배제
- 가게 or 주소 문자열에 자음 or 모음이 없다는 전제
- 초성 중성 종성 예상 검색제안도 배제
 - 1. searchText의 끝문자검사해서 자음이나 모음이 아닐때 통신하기
- 2. 공백을 구분하여 배열로 관리

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 검색어 제안
- input value 마지막 값이 자음 또는 모음일때 통신을 하지 않습니다.
- input value의 값을 공백을 기준으로 단어 배열을 생성하여 단어배열에있는 모든 요소가 통신을 통해서 받은 데이터에 하나라도 포함되지않으면 검색어 제안에서 제외됩니다.
- state로 관리되는 단어배열이 업데이트 될때마다 통신을 합니다.
- 단어배열의 각 요소는 자음과 모음을 포함하지 않습니다.

2. 검색어 제안 리스트중 특정 가게 클릭시 해당 가게 페이지로 이동(useNavigate hooks)

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 평소 구현 해 보고싶은 기능이었습니다. 쉽지않을 거라고 생각했지만 역시 어렵네요. 꾸준히 리펙토링해서 복잡도 개선과 초성 검색제안 등의 기능 개선을 해보고싶습니다.

<br />

## :: 기타 질문 및 특이 사항
- 
